### PR TITLE
Moved java driver version back to 4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <driver.version>4.14.1</driver.version>
+    <driver.version>4.10.0</driver.version>
     <dsbulk.version>1.10.0</dsbulk.version>
   </properties>
   <dependencies>


### PR DESCRIPTION
There was a problem with java driver 4.11+ with the codec frame size that we need to sort out before we upgrade further.