### PR TITLE
Ability to force protocol version

### DIFF
--- a/src/main/java/com/datastax/migrator/live/TableLiveMigrator.java
+++ b/src/main/java/com/datastax/migrator/live/TableLiveMigrator.java
@@ -230,6 +230,10 @@ public abstract class TableLiveMigrator extends TableProcessor {
               .collect(Collectors.joining(","));
       args.add("[" + hosts + "]");
     }
+    if (settings.exportSettings.clusterInfo.protocolVersion != null) {
+      args.add("--driver.advanced.protocol.version");
+      args.add(settings.exportSettings.clusterInfo.protocolVersion);
+    }
     if (settings.exportSettings.credentials != null) {
       args.add("-u");
       args.add(settings.exportSettings.credentials.username);
@@ -283,6 +287,10 @@ public abstract class TableLiveMigrator extends TableProcessor {
       args.add(settings.importSettings.credentials.username);
       args.add("-p");
       args.add(String.valueOf(settings.importSettings.credentials.password));
+    }
+    if (settings.importSettings.clusterInfo.protocolVersion != null) {
+      args.add("--driver.advanced.protocol.version");
+      args.add(settings.importSettings.clusterInfo.protocolVersion);
     }
     args.add("-url");
     args.add(String.valueOf(tableDataDir));

--- a/src/main/java/com/datastax/migrator/script/SchemaScriptGenerator.java
+++ b/src/main/java/com/datastax/migrator/script/SchemaScriptGenerator.java
@@ -133,6 +133,12 @@ public class SchemaScriptGenerator {
                 ? String.valueOf(settings.exportSettings.credentials.password)
                 : "")
             + "}\"");
+    writer.println(
+        "protocol_version=\"${MIGRATOR_EXPORT_PROTOCOL_VERSION:-"
+            + (settings.exportSettings.clusterInfo.protocolVersion != null
+                ? settings.exportSettings.clusterInfo.protocolVersion
+                : "")
+            + "}\"");
     writer.println("dsbulk_cmd=\"${MIGRATOR_EXPORT_CMD:-" + settings.dsbulkCmd + "}\"");
     writer.println("dsbulk_logs=\"${MIGRATOR_EXPORT_LOG_DIR:-" + settings.dsbulkLogDir + "}\"");
     writer.println("data_dir=\"${MIGRATOR_EXPORT_DATA_DIR:-" + settings.dataDir + "}\"");
@@ -190,6 +196,12 @@ public class SchemaScriptGenerator {
             + (settings.importSettings.credentials != null
                 ? String.valueOf(settings.importSettings.credentials.password)
                 : "")
+            + "}\"");
+    writer.println(
+        "protocol_version=\"${MIGRATOR_IMPORT_PROTOCOL_VERSION:-"
+            + (settings.importSettings.clusterInfo.protocolVersion != null
+            ? settings.importSettings.clusterInfo.protocolVersion
+            : "")
             + "}\"");
     writer.println("dsbulk_cmd=\"${MIGRATOR_IMPORT_CMD:-" + settings.dsbulkCmd + "}\"");
     writer.println("dsbulk_logs=\"${MIGRATOR_IMPORT_LOG_DIR:-" + settings.dsbulkLogDir + "}\"");

--- a/src/main/java/com/datastax/migrator/script/TableScriptGenerator.java
+++ b/src/main/java/com/datastax/migrator/script/TableScriptGenerator.java
@@ -79,6 +79,7 @@ public class TableScriptGenerator extends TableProcessor {
     }
     writer.println("    $([[ -z \"$username\" ]] || echo \"-u \\\"${username}\\\"\") \\");
     writer.println("    $([[ -z \"$password\" ]] || echo \"-p \\\"${password}\\\"\") \\");
+    writer.println("    $([[ -z \"$protocol_version\" ]] || echo \"--driver.advanced.protocol.version \\\"${protocol_version}\\\"\") \\");
     writer.println("    -url " + tableDataDir + " \\");
     writer.println("    -maxRecords \"$max_records\" \\");
     writer.println("    -maxConcurrentFiles \"$max_concurrent_files\" \\");
@@ -150,6 +151,7 @@ public class TableScriptGenerator extends TableProcessor {
     }
     writer.println("    $([[ -z \"$username\" ]] || echo \"-u \\\"${username}\\\"\") \\");
     writer.println("    $([[ -z \"$password\" ]] || echo \"-p \\\"${password}\\\"\") \\");
+    writer.println("    $([[ -z \"$protocol_version\" ]] || echo \"--driver.advanced.protocol.version \\\"${protocol_version}\\\"\") \\");
     writer.println("    -url " + tableDataDir + " \\");
     writer.println("    -maxErrors \"$max_errors\" \\");
     writer.println("    -maxConcurrentFiles \"$max_concurrent_files\" \\");

--- a/src/main/java/com/datastax/migrator/settings/ClusterInfo.java
+++ b/src/main/java/com/datastax/migrator/settings/ClusterInfo.java
@@ -27,6 +27,8 @@ public interface ClusterInfo {
 
   Path getBundle();
 
+  String getProtocolVersion();
+
   default boolean isAstra() {
     return getBundle() != null;
   }

--- a/src/main/java/com/datastax/migrator/settings/ExportSettings.java
+++ b/src/main/java/com/datastax/migrator/settings/ExportSettings.java
@@ -55,6 +55,15 @@ public class ExportSettings {
         required = true)
     public Path bundle;
 
+    @Option(
+        names = "--export-protocol-version",
+        paramLabel = "VERSION",
+        description =
+            "The protocol version to use to connect to the origin cluster, e.g. 'V4'. "
+                + "If not specified, the driver will negotiate the highest version supported by both "
+                + "the client and the server.")
+    public String protocolVersion;
+
     @Override
     public boolean isOrigin() {
       return true;
@@ -76,6 +85,11 @@ public class ExportSettings {
     @Override
     public Path getBundle() {
       return bundle;
+    }
+
+    @Override
+    public String getProtocolVersion() {
+      return protocolVersion;
     }
   }
 

--- a/src/main/java/com/datastax/migrator/settings/ImportSettings.java
+++ b/src/main/java/com/datastax/migrator/settings/ImportSettings.java
@@ -57,6 +57,15 @@ public class ImportSettings {
         required = true)
     public Path bundle;
 
+    @Option(
+        names = "--import-protocol-version",
+        paramLabel = "VERSION",
+        description =
+            "The protocol version to use to connect to the target cluster, e.g. 'V4'. "
+                + "If not specified, the driver will negotiate the highest version supported by both "
+                + "the client and the server.")
+    public String protocolVersion;
+
     @Override
     public boolean isOrigin() {
       return false;
@@ -78,6 +87,11 @@ public class ImportSettings {
     @Override
     public Path getBundle() {
       return bundle;
+    }
+
+    @Override
+    public String getProtocolVersion() {
+      return protocolVersion;
     }
   }
 

--- a/src/test/java/com/datastax/migrator/DdlGenerationIT.java
+++ b/src/test/java/com/datastax/migrator/DdlGenerationIT.java
@@ -113,6 +113,7 @@ class DdlGenerationIT extends SimulacronITBase {
         Collections.singletonList(HostAndPort.fromString(originHost));
     settings.clusterInfo.hostsAndPorts =
         Collections.singletonList(HostAndPort.fromString(targetHost));
+    settings.clusterInfo.protocolVersion = "V4";
     return settings;
   }
 }

--- a/src/test/java/com/datastax/migrator/LiveMigrationIT.java
+++ b/src/test/java/com/datastax/migrator/LiveMigrationIT.java
@@ -136,12 +136,10 @@ class LiveMigrationIT extends SimulacronITBase {
         Collections.singletonList(HostAndPort.fromString(originHost));
     settings.importSettings.clusterInfo.hostsAndPorts =
         Collections.singletonList(HostAndPort.fromString(targetHost));
+    settings.importSettings.clusterInfo.protocolVersion = "V4";
+    settings.exportSettings.clusterInfo.protocolVersion = "V4";
     settings.dsbulkEmbedded = embedded;
     settings.dsbulkLogDir = logsDir;
-    settings.importSettings.extraDsbulkOptions =
-        List.of("--datastax-java-driver.advanced.protocol.version=V3");
-    settings.exportSettings.extraDsbulkOptions =
-        List.of("--datastax-java-driver.advanced.protocol.version=V3");
     if (!embedded) {
       if (isWindows()) {
         settings.dsbulkCmd = dsbulkDir.resolve("bin").resolve("dsbulk.cmd").toString();

--- a/src/test/java/com/datastax/migrator/ScriptGenerationIT.java
+++ b/src/test/java/com/datastax/migrator/ScriptGenerationIT.java
@@ -94,6 +94,8 @@ class ScriptGenerationIT extends SimulacronITBase {
         Collections.singletonList(HostAndPort.fromString(originHost));
     settings.importSettings.clusterInfo.hostsAndPorts =
         Collections.singletonList(HostAndPort.fromString(targetHost));
+    settings.importSettings.clusterInfo.protocolVersion = "V4";
+    settings.exportSettings.clusterInfo.protocolVersion = "V4";
     settings.dsbulkLogDir = logsDir;
     return settings;
   }


### PR DESCRIPTION
This commit introduces two settings, export-protocol-version and import-protocol-version, that can be used to force the protocol version to use when contacting the origin or target clusters respectively.