### PR TITLE
Fix IntelliJ Run configurations

### DIFF
--- a/idea/runConfigurations/DDL Generator (Astra targets).run.xml
+++ b/idea/runConfigurations/DDL Generator (Astra targets).run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="DDL Generator (Astra targets)" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="generate-ddl --data-dir=target/export --export-host=127.0.0.1:9042 --export-username=cassandra --export-password=s3cr3t --optimize-for-astra" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/DDL Generator.run.xml
+++ b/idea/runConfigurations/DDL Generator.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="DDL Generator" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="generate-ddl --data-dir=target/export --export-host=127.0.0.1:9042 --export-username=cassandra --export-password=s3cr3t" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/Live Migrator (embedded).run.xml
+++ b/idea/runConfigurations/Live Migrator (embedded).run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Live Migrator (embedded)" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="migrate-live --data-dir=target/export --table-types=all --export-host=127.0.0.1:9042 --export-username=cassandra --export-password=cassandra --import-host=127.0.1.1:9042 --import-username=cassandra --import-password --dsbulk-use-embedded" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/Live Migrator (external).run.xml
+++ b/idea/runConfigurations/Live Migrator (external).run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Live Migrator (external)" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="migrate-live --data-dir=target/export --keyspaces=(keyspace1|keyspace2) --tables=(table_.*|MyTable_\d+) --table-types=all --export-host=127.0.0.1:9042 --export-username=cassandra --export-password --import-host=127.0.0.1:9042 --import-username=cassandra --import-password" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/Live Migrator Help.run.xml
+++ b/idea/runConfigurations/Live Migrator Help.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Live Migrator Help" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="migrate-live --help" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/Script Generator Help.run.xml
+++ b/idea/runConfigurations/Script Generator Help.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Script Generator Help" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="generate-script --help" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/Script Generator.run.xml
+++ b/idea/runConfigurations/Script Generator.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Script Generator" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="generate-script --data-dir=target/export --table-types=all --dsbulk-log-dir=target/logs --export-host=127.0.0.1:9042 --export-host=127.0.0.2:9042 --export-username=cassandra --export-password --export-dsbulk-option &quot;--connector.csv.maxCharsPerColumn=65536&quot; --export-dsbulk-option &quot;--executor.maxPerSecond=1000&quot; --import-host=127.0.1.1:9042 --import-username=cassandra --import-password --import-dsbulk-option &quot;--connector.csv.maxCharsPerColumn=65536&quot; --import-dsbulk-option &quot;--executor.maxPerSecond=1000&quot;" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/Show Global Help.run.xml
+++ b/idea/runConfigurations/Show Global Help.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Show Global Help" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="--help" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/idea/runConfigurations/Show Version.run.xml
+++ b/idea/runConfigurations/Show Version.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Show Version" type="Application" factoryName="Application">
-    <option name="MAIN_CLASS_NAME" value="com.datastax.cloudgate.migrator.CloudGateMigrator" />
-    <module name="cloud-gate-schema-migrator" />
+    <option name="MAIN_CLASS_NAME" value="com.datastax.migrator.DSBulkMigrator" />
+    <module name="dsbulk-migrator" />
     <option name="PROGRAM_PARAMETERS" value="--version" />
     <method v="2">
       <option name="Make" enabled="true" />


### PR DESCRIPTION
This commit fixes some IntelliJ Run configurations that were broken because they were still pointing to the pre-OSS version of the migrator.